### PR TITLE
Add a separate parser

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+addopts = --doctest-modules

--- a/stack.py
+++ b/stack.py
@@ -2,22 +2,40 @@
 from __future__ import division
 
 
-sigil_to_op = {
-    '←': 'push',
-    '→': 'pop',
-    '↔': 'swap',
-    '↑': 'jump',
-    '+': 'add',
-    '-': 'sub',
-    '−': 'sub',  # A minus isn't the same thing as a hyphen!
-    '*': 'mul',
-    '×': 'mul',
-    '/': 'div',
-    '÷': 'div',
-    '^': 'pow',
-    '!': 'not',
-    '¬': 'not',
-}
+class Instr(object):
+    sigil_to_op = {
+        '←': 'push', '→': 'pop',
+        '↔': 'swap',
+        '↑': 'jump',
+        '+': 'add',
+        '-': 'sub', '−': 'sub',  # A minus isn't the same thing as a hyphen!
+        '*': 'mul', '×': 'mul',
+        '/': 'div', '÷': 'div',
+        '^': 'pow',
+        '!': 'not', '¬': 'not',
+    }
+
+    def __init__(self, op, args=None, prefix=None):
+        args = [] if args is None else args
+        prefix = [] if prefix is None else prefix
+
+        if op in Instr.sigil_to_op:
+            op = Instr.sigil_to_op[op]
+        self.op, self.args, self.prefix = op, args, prefix
+
+    def __repr__(self):
+        if self.prefix:
+            return 'Instr({!r}, {!r}, {!r})'.format(
+                self.op, self.args, self.prefix)
+        elif self.args:
+            return 'Instr({!r}, {!r})'.format(self.op, self.args)
+        else:
+            return 'Instr({!r})'.format(self.op)
+
+    def __eq__(self, other):
+        return (self.op == other.op and
+                self.args == other.args and
+                self.prefix == other.prefix)
 
 
 def parse_program(code):
@@ -25,22 +43,20 @@ def parse_program(code):
     Take a source code string and yield a sequence of instructions
 
     >>> list(parse_program('push 1'))
-    [{'prefix': [], 'args': [1.0], 'op': 'push'}]
+    [Instr('push', [1.0])]
 
     Various sigils from Unicode are supported as alternate versions of
     operations, for example:
     >>> list(parse_program('← 1'))
-    [{'prefix': [], 'args': [1.0], 'op': 'push'}]
+    [Instr('push', [1.0])]
     >>> list(parse_program('↔'))
-    [{'prefix': [], 'args': [], 'op': 'swap'}]
+    [Instr('swap')]
     """
     for line in code.split('\n'):
         parts = line.split()
         op = parts[0]
-        if op in sigil_to_op:
-            op = sigil_to_op[op]
         args = [float(arg) for arg in parts[1:]]
-        yield {'op': op, 'prefix': [], 'args': args}
+        yield Instr(op, args)
 
 
 # TODO: This is pretty stringly typed, perhaps return a custom object?

--- a/stack.py
+++ b/stack.py
@@ -1,5 +1,18 @@
-# Make Python 2 use float division instead of integer division
 from __future__ import division
+
+
+def parse_program(code):
+    """
+    Take a source code string and yield a sequence of instructions
+
+    >>> list(parse_program('push 1'))
+    [{'prefix': [], 'args': [1.0], 'op': 'push'}]
+    """
+    for line in code.split('\n'):
+        parts = line.split()
+        op = parts[0]
+        args = [float(arg) for arg in parts[1:]]
+        yield {'op': op, 'prefix': [], 'args': args}
 
 
 # TODO: This is pretty stringly typed, perhaps return a custom object?
@@ -64,5 +77,3 @@ def is_operator(opcode):
         return True
     else:
         return False
-
-print(eval_program("push 1; push 2; add; push 5; multiply; push 3; divide"))

--- a/stack.py
+++ b/stack.py
@@ -1,16 +1,44 @@
+# -*- coding: utf-8 -*-
 from __future__ import division
 
 
+sigil_to_op = {
+    '←': 'push',
+    '→': 'pop',
+    '↔': 'swap',
+    '↑': 'jump',
+    '+': 'add',
+    '-': 'sub',
+    '−': 'sub',  # A minus isn't the same thing as a hyphen!
+    '*': 'mul',
+    '×': 'mul',
+    '/': 'div',
+    '÷': 'div',
+    '^': 'pow',
+    '!': 'not',
+    '¬': 'not',
+}
+
+
 def parse_program(code):
-    """
+    r"""
     Take a source code string and yield a sequence of instructions
 
     >>> list(parse_program('push 1'))
     [{'prefix': [], 'args': [1.0], 'op': 'push'}]
+
+    Various sigils from Unicode are supported as alternate versions of
+    operations, for example:
+    >>> list(parse_program('← 1'))
+    [{'prefix': [], 'args': [1.0], 'op': 'push'}]
+    >>> list(parse_program('↔'))
+    [{'prefix': [], 'args': [], 'op': 'swap'}]
     """
     for line in code.split('\n'):
         parts = line.split()
         op = parts[0]
+        if op in sigil_to_op:
+            op = sigil_to_op[op]
         args = [float(arg) for arg in parts[1:]]
         yield {'op': op, 'prefix': [], 'args': args}
 

--- a/stack.py
+++ b/stack.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 from __future__ import division
+import re
 
 
 class Instr(object):
@@ -52,8 +53,10 @@ def parse_program(code):
     >>> list(parse_program('↔'))
     [Instr('swap')]
     """
-    for line in code.split('\n'):
-        parts = line.split()
+    for line in re.split('\n|;', code):
+        parts = line.strip().split()
+        if not parts:
+            continue
         op = parts[0]
         args = [float(arg) for arg in parts[1:]]
         yield Instr(op, args)

--- a/stack.py
+++ b/stack.py
@@ -74,7 +74,7 @@ def eval_program(program):
             b = stack.pop()
             a = stack.pop()
             # b is the top of the stack, and a is the item before it, so
-            # doing `push 5 ; div` is division by 5
+            # `... ; push 5 ; div` is dividing the result of `...` by 5.
             if instr.op == 'add':
                 c = a + b
             elif instr.op == 'sub':
@@ -102,12 +102,5 @@ def eval_program(program):
     return stack
 
 
-def get_argument(instuction, default):
-    try:
-        return int(instuction[1])
-    except IndexError:
-        return default
-
-
 def is_operator(op):
-    return op in ['add', 'sub', 'mul', 'div']
+    return op in ('add', 'sub', 'mul', 'div', 'pow')

--- a/test_stack.py
+++ b/test_stack.py
@@ -12,8 +12,15 @@ def test_unicode_sigil():
 
 
 def test_parse():
-    program = stack.parse_program('push 1\npop\nswap')
-    assert list(program) == [Instr('push', [1]), Instr('pop'), Instr('swap')]
+    expected = [Instr('push', [1]), Instr('pop'), Instr('swap')]
+    # Any mix of semicolons and newlines should work
+    assert list(stack.parse_program('push 1\npop\nswap')) == expected
+    assert list(stack.parse_program('push 1; pop; swap')) == expected
+    assert list(stack.parse_program('push 1; pop\nswap')) == expected
+    # Spaces shouldn't matter for semicolons
+    assert list(stack.parse_program('push 1 ;pop;  swap')) == expected
+    # And empty instructions should be skipped
+    assert list(stack.parse_program('push 1 ;;; pop\n;\nswap')) == expected
 
 
 def test_parse_unicode():

--- a/test_stack.py
+++ b/test_stack.py
@@ -1,7 +1,7 @@
 from __future__ import division
 
 import stack
-from stack import next_instruction, eval_program, Instr
+from stack import eval_program, Instr
 
 import pytest
 
@@ -29,15 +29,6 @@ def test_parse_unicode():
         assert instruction == Instr(Instr.sigil_to_op[sigil])
 
 
-def test_next_instruction():
-    program = next_instruction("push 1; pop; swap;")
-    assert next(program) == "push 1"
-    assert next(program) == "pop"
-    assert next(program) == "swap"
-    with pytest.raises(StopIteration):
-        next(program)
-
-
 def test_push_and_pop():
     assert eval_program("push 1; push 2; push 3;") == [1, 2, 3]
     assert eval_program("push 2; pop") == []
@@ -48,34 +39,37 @@ def test_push_and_pop():
 
 def test_simple_operators():
     assert eval_program("push 10; push 20; add;") == [30]
-    assert eval_program("push 10; push 5; subtract;") == [5]
-    assert eval_program("push 10; push 20; subtract;") == [-10]
-    assert eval_program("push 10; push 0; multiply;") == [0]
-    assert eval_program("push 10; push 10; multiply;") == [100]
-    assert eval_program("push 10; push 2; divide") == [5.0]
-    assert eval_program("push 3; push 2; divide") == [1.5]
+    assert eval_program("push 10; push 5; sub;") == [5]
+    assert eval_program("push 10; push 20; sub;") == [-10]
+    assert eval_program("push 10; push 0; mul;") == [0]
+    assert eval_program("push 10; push 10; mul;") == [100]
+    assert eval_program("push 10; push 2; div") == [5.0]
+    assert eval_program("push 3; push 2; div") == [1.5]
     with pytest.raises(IndexError):
         assert eval_program("push 1; add")
-        assert eval_program("subtract; push 1")
-        assert eval_program("push 1; push 2; pop; multiply")
-        assert eval_program("divide")
+    with pytest.raises(IndexError):
+        assert eval_program("sub; push 1")
+    with pytest.raises(IndexError):
+        assert eval_program("push 1; push 2; pop; mul")
+    with pytest.raises(IndexError):
+        assert eval_program("div")
     with pytest.raises(ZeroDivisionError):
         # IDEA: division by zero pushes nothing? halts program? pushes zero?
-        assert eval_program("push 1; push 0; divide")
+        assert eval_program("push 1; push 0; div")
 
 
 def test_float_division():
-    assert eval_program("push 5; push 2; divide") == [2.5]
-    assert eval_program("push 4; push 5; divide") == [0.8]
-    assert eval_program("push 1; push 100; divide") == [0.01]
+    assert eval_program("push 5; push 2; div") == [2.5]
+    assert eval_program("push 4; push 5; div") == [0.8]
+    assert eval_program("push 1; push 100; div") == [0.01]
 
 
 def test_complex_operators():
-    program = "push 2; push 3; push 5; add; multiply"
+    program = "push 2; push 3; push 5; add; mul"
     assert eval_program(program) == [2 * (3 + 5)]
-    program = "push 36; push 24; push 6; divide; divide;"
+    program = "push 36; push 24; push 6; div; div;"
     assert eval_program(program) == [36 / (24 / 6)]
-    program = "push 10; push 4; subtract; push 6; push 2; subtract; multiply"
+    program = "push 10; push 4; sub; push 6; push 2; sub; mul"
     assert eval_program(program) == [(10 - 4) * (6 - 2)]
 
 
@@ -88,8 +82,11 @@ def test_swap():
         4, 2, 3, 1, ]
     with pytest.raises(IndexError):
         assert eval_program("swap")
+    with pytest.raises(IndexError):
         assert eval_program("push 1; swap")
+    with pytest.raises(IndexError):
         assert eval_program("push 1; push 2; swap 2")
+    with pytest.raises(IndexError):
         assert eval_program("push 1; push 2; push 3; swap 3")
 
 
@@ -100,7 +97,7 @@ def test_dup():
     assert eval_program("push 1; push 2; dup 2") == [1, 2, 1, 2]
     assert eval_program("push 1; dup; push 2; dup 3") == [1, 1, 2, 1, 1, 2]
     with pytest.raises(IndexError):
-        # Should duping an empty stack be an error?
-        # It technially duplicates the top element, which is nothing.
+        # Cannot duplicate the top element, since there is not top element
         assert eval_program("dup")
+    with pytest.raises(IndexError):
         assert eval_program("push 1; dup 2")

--- a/test_stack.py
+++ b/test_stack.py
@@ -15,6 +15,13 @@ def test_parse():
     ]
 
 
+def test_parse_unicode():
+    for sigil in stack.sigil_to_op:
+        instruction = next(stack.parse_program(sigil))
+        expected = {'op': stack.sigil_to_op[sigil], 'prefix': [], 'args': []}
+        assert instruction == expected
+
+
 def test_next_instruction():
     program = next_instruction("push 1; pop; swap;")
     assert next(program) == "push 1"

--- a/test_stack.py
+++ b/test_stack.py
@@ -6,6 +6,15 @@ from stack import next_instruction, eval_program
 import pytest
 
 
+def test_parse():
+    program = stack.parse_program('push 1\npop\nswap')
+    assert list(program) == [
+        {'op': 'push', 'prefix': [], 'args': [1]},
+        {'op': 'pop', 'prefix': [], 'args': []},
+        {'op': 'swap', 'prefix': [], 'args': []},
+    ]
+
+
 def test_next_instruction():
     program = next_instruction("push 1; pop; swap;")
     assert next(program) == "push 1"

--- a/test_stack.py
+++ b/test_stack.py
@@ -33,7 +33,7 @@ def test_push_and_pop():
     assert eval_program("push 1; push 2; push 3;") == [1, 2, 3]
     assert eval_program("push 2; pop") == []
     with pytest.raises(IndexError):
-        # IDEA: poping an empty list does nothing instead of index error?
+        # IDEA: popping an empty list does nothing instead of index error?
         eval_program("pop")
 
 
@@ -45,6 +45,7 @@ def test_simple_operators():
     assert eval_program("push 10; push 10; mul;") == [100]
     assert eval_program("push 10; push 2; div") == [5.0]
     assert eval_program("push 3; push 2; div") == [1.5]
+    assert eval_program("push 4; push 4; pow") == [4**4]
     with pytest.raises(IndexError):
         assert eval_program("push 1; add")
     with pytest.raises(IndexError):

--- a/test_stack.py
+++ b/test_stack.py
@@ -1,25 +1,25 @@
 from __future__ import division
 
 import stack
-from stack import next_instruction, eval_program
+from stack import next_instruction, eval_program, Instr
 
 import pytest
 
 
+def test_unicode_sigil():
+    for sigil in Instr.sigil_to_op:
+        assert Instr(sigil) == Instr(Instr.sigil_to_op[sigil])
+
+
 def test_parse():
     program = stack.parse_program('push 1\npop\nswap')
-    assert list(program) == [
-        {'op': 'push', 'prefix': [], 'args': [1]},
-        {'op': 'pop', 'prefix': [], 'args': []},
-        {'op': 'swap', 'prefix': [], 'args': []},
-    ]
+    assert list(program) == [Instr('push', [1]), Instr('pop'), Instr('swap')]
 
 
 def test_parse_unicode():
-    for sigil in stack.sigil_to_op:
+    for sigil in Instr.sigil_to_op:
         instruction = next(stack.parse_program(sigil))
-        expected = {'op': stack.sigil_to_op[sigil], 'prefix': [], 'args': []}
-        assert instruction == expected
+        assert instruction == Instr(Instr.sigil_to_op[sigil])
 
 
 def test_next_instruction():


### PR DESCRIPTION
The current interpreter works directly on text, which might get annoying as more features and syntax are added. This simultaneously adds support for Unicode sigils instead of words, and changes some of the full operator names (like `subtract` -> `sub`). Finally, semicolons now behave more like Python: they're optional between lines (and discouraged) but can be used to separate operations within a single line.
