### PR TITLE
Add nop instruction

### DIFF
--- a/stack.py
+++ b/stack.py
@@ -38,14 +38,16 @@ sigil_to_op = {
     '<': 'lt',
     '>': 'gt',
     '<=': 'le', '≤': 'le',
-    '>=': 'ge', '≥': 'ge'
+    '>=': 'ge', '≥': 'ge',
+    '∅': 'nop',
 }
 
 valid_ops = [
     'push', 'pop', 'dup', 'swap', 'jump',
     'add', 'sub', 'mul', 'div', 'pow',
     'eq', 'lt', 'gt', 'le', 'ge',
-    'not'
+    'not',
+    'nop',
 ]
 
 arg_types = {
@@ -55,6 +57,7 @@ arg_types = {
     'add': [[]], 'sub': [[]], 'mul': [[]], 'div': [[]], 'pow': [[]],
     'eq': [[]], 'lt': [[]], 'gt': [[]], 'le': [[]], 'ge': [[]],
     'not': [[]],
+    'nop': [[]],
 }
 
 
@@ -167,6 +170,10 @@ def eval_program(program):
             if current_instr > len(instructions) or current_instr < 0:
                 raise IndexError("Jump address {} out of bounds ({})".format(
                     current_instr, len(instructions)-1))
+        elif instr.op == 'nop':
+            pass
+        else:
+            raise ValueError('Unknown instruction {}'.format(instr))
     return stack
 
 

--- a/test_stack.py
+++ b/test_stack.py
@@ -114,6 +114,7 @@ def test_swap():
     with pytest.raises(IndexError):
         eval_program("push 1; push 2; swap 2")
     with pytest.raises(IndexError):
+
         eval_program("push 1; push 2; push 3; swap 3")
 
 
@@ -209,3 +210,8 @@ def test_dynamic_jump():
         eval_program("push 2; jump")
     with pytest.raises(IndexError):
         eval_program("push -2; jump; jump 0")
+
+
+def test_nop():
+    assert eval_program("nop") == []
+    assert eval_program("∅") == []


### PR DESCRIPTION
Sometimes you want to occupy space in the code temporarily, so this
commit adds `nop`, which is equivalent to `jump 1`, in that it does
nothing at all.

Resolves #19
